### PR TITLE
[feature/inclusive-selector] Switching ID for more inclusive CSS selector in axe-e2e script

### DIFF
--- a/test-scripts/axe-e2e/README.md
+++ b/test-scripts/axe-e2e/README.md
@@ -43,7 +43,7 @@ them to a terminal window, or CSV file. The script runs automatically, and is ta
 * `$ npm run test:console-light` to output errors to a light terminal window
 * `$ npm run test:report` to output errors to `/csv-reports/base.csv`
 
-## If you receive a Terminal error after updating
+## Troubleshooting
 
 The new version of axe-e2e may cause an error the first time you run `yarn | npm run test`. If this happens, run the following commands from your terminal prompt:
 

--- a/test-scripts/axe-e2e/README.md
+++ b/test-scripts/axe-e2e/README.md
@@ -50,9 +50,9 @@ The new version of axe-e2e may cause an error the first time you run `yarn | npm
 ### If using Yarn:
 
 1. `$ yarn install`
-2. `$ yarn test:<PREFERRED-TEST>` Replace `<PREFERRED-TEST>` with one of the yarn commands in Step 7 above.
+2. `$ yarn test:<PREFERRED-TEST>`.<br/>Replace `<PREFERRED-TEST>` with one of the yarn commands in Step 7 above.
 
 ### If using npm:
 
 1. `$ npm install`
-2. `$ npm run test:<PREFERRED-TEST>` Replace `<PREFERRED-TEST>` with one of the npm commands in Step 7 above.
+2. `$ npm run test:<PREFERRED-TEST>`.<br/>Replace `<PREFERRED-TEST>` with one of the npm commands in Step 7 above.

--- a/test-scripts/axe-e2e/README.md
+++ b/test-scripts/axe-e2e/README.md
@@ -42,3 +42,17 @@ them to a terminal window, or CSV file. The script runs automatically, and is ta
 * `$ npm run test:console-dark` to output errors to a dark terminal window
 * `$ npm run test:console-light` to output errors to a light terminal window
 * `$ npm run test:report` to output errors to `/csv-reports/base.csv`
+
+## If you receive a Terminal error after updating
+
+The new version of axe-e2e may cause an error the first time you run `yarn | npm run test`. If this happens, run the following commands from your terminal prompt:
+
+### If using Yarn:
+
+1. `$ yarn install`
+2. `$ yarn test:<PREFERRED-TEST>` Replace `<PREFERRED-TEST>` with one of the yarn commands in Step 7 above.
+
+### If using npm:
+
+1. `$ npm install`
+2. `$ npm run test:<PREFERRED-TEST>` Replace `<PREFERRED-TEST>` with one of the npm commands in Step 7 above.

--- a/test-scripts/axe-e2e/README.md
+++ b/test-scripts/axe-e2e/README.md
@@ -25,10 +25,10 @@ them to a terminal window, or CSV file. The script runs automatically, and is ta
 4. Type `$ yarn install` at your terminal prompt ($)
 5. Name your sitemap file `sitemap.xml` and add it to the
    `axe-e2e/fixtures` directory. Ensure your XML file follows the same format as `sitemap.example.xml`.
-6. `index.js` passes Webdriver an `id="content"` argument by default. If you use a
-   different ID on your pages, open `axe-e2e/index.js` and edit the
-second argument on lines 5, 8, and 11. Be sure to pass a `<String>` in quotation
-marks, or Webdriver will throw an error.
+6. `index.js` passes Webdriver a `css selector="#content"` argument by default. If you use a
+   different [CSS selector](https://www.w3.org/TR/CSS/#selectors) on your pages, open `axe-e2e/index.js` and edit the
+   second argument on lines 5, 8, and 11. Be sure to pass a `<String>` in quotation
+   marks, or Webdriver will throw an error. For more information about Webdriver selectors, see [Webdriver > Class > By](https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/by_exports_By.html) documentation.
 7. Run one or more of the following commands from your terminal prompt:
 
 ### If using Yarn:

--- a/test-scripts/axe-e2e/index.js
+++ b/test-scripts/axe-e2e/index.js
@@ -2,11 +2,11 @@ var reporter = require("./scripts/e2e-axe");
 
 if (process.env["NODE_ENV"] === "report") {
   // Output CSV report in ./csv-reports
-  reporter.createCSVReport("./fixtures/sitemap.xml", "content");
+  reporter.createCSVReport("./fixtures/sitemap.xml", "#content");
 } else if (process.env["NODE_ENV"] === "consoleLight") {
   // Output to console with light display
-  reporter.scanToConsole("./fixtures/sitemap.xml", "content", "light");
+  reporter.scanToConsole("./fixtures/sitemap.xml", "#content", "light");
 } else {
   // Output to console with dark display
-  reporter.scanToConsole("./fixtures/sitemap.xml", "content", "dark");
+  reporter.scanToConsole("./fixtures/sitemap.xml", "#content", "dark");
 }

--- a/test-scripts/axe-e2e/package.json
+++ b/test-scripts/axe-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axe-core-js-e2e-analyzer",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A script to evaluate and output axe-core errors for multi-page sites using Selenium Webdriver and Chrome headless",
   "main": "index.js",
   "author": "Trevor Pierce, Ad Hoc LLC",

--- a/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
+++ b/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
@@ -44,7 +44,7 @@ var axeBuilder = AxeBuilder(driver).configure({
   reporter: "v2",
   runOnly: {
     type: "tag",
-    values: ["wcag2a", "wcag2aa", "section508"]
+    values: ["section508", "wcag2a", "wcag2aa", "best-practice"]
   }
 });
 

--- a/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
+++ b/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
@@ -53,6 +53,9 @@ var axeBuilder = AxeBuilder(driver).configure({
  *
  * @param {String} Path to sitemap.xml file used to create array of URLs to scan
  * @param {String} ID of container element WebDriver will look for
+ *
+ * Documentation for Webdriver selector functions:
+ * https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_By.html
  */
 exports.checkA11y = function(dataArray, el) {
   dataArray.forEach(function(url) {

--- a/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
+++ b/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
@@ -57,7 +57,7 @@ var axeBuilder = AxeBuilder(driver).configure({
 exports.checkA11y = function(dataArray, el) {
   dataArray.forEach(function(url) {
     driver.get(url);
-    driver.wait(until.elementLocated(By.id(el)), 10000).then(function() {
+    driver.wait(until.elementLocated(By.css(el)), 10000).then(function() {
       axeBuilder.analyze(function(results) {
         AxeReports.createCsvReportRow(results);
       });

--- a/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
+++ b/test-scripts/axe-e2e/utilities/a11y-e2e-utilities.js
@@ -72,11 +72,14 @@ exports.checkA11y = function(dataArray, el) {
  * @param {String} Path to sitemap.xml file used to create array of URLs to scan
  * @param {String} ID of container element WebDriver will look for
  * @param {String} Set console preference for darker or lighter background colors
+ *
+ * Documentation for Webdriver selector functions:
+ * https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_By.html
  */
 exports.checkA11yConsole = function(dataArray, el, consoleColor) {
   dataArray.forEach(function(url) {
     driver.get(url);
-    driver.wait(until.elementLocated(By.id(el)), 10000).then(function() {
+    driver.wait(until.elementLocated(By.css(el)), 10000).then(function() {
       axeBuilder.analyze(function(results) {
         AxeReports.createConsoleReportRow(results, consoleColor);
       });


### PR DESCRIPTION
The previous version of this script assumed an ID was always available for Webdriver to reference. This was an overly naive implementation, so I switched the `By.id()` method for `By.css()` in the axe-e2e-utliities.js file.

I updated the index.js file second argument to read `#content`, so identifying the same `id="content"` as before, but allowing users to enter classes, attribute selectors, or DOM elements as their `el` <String>.